### PR TITLE
Skip migration sine until crate db

### DIFF
--- a/codedeploy/migrate-db.sh
+++ b/codedeploy/migrate-db.sh
@@ -1,2 +1,2 @@
 . /home/ubuntu/.envs
-cd /home/ubuntu/cg-backend && npx sequelize db:migrate > /dev/null
+# cd /home/ubuntu/cg-backend && npx sequelize db:migrate > /dev/null


### PR DESCRIPTION
We need to skip the migration til we create the db (cause sequelize will try to connect and fail)