### PR TITLE
MP/ Add customer/seller fields to user

### DIFF
--- a/src/controllers/user/signup.js
+++ b/src/controllers/user/signup.js
@@ -1,8 +1,9 @@
-export default async ({ email, password, name }, { cognitoService, userModel }) => {
+export default async ({ email, password, ...restUserInput }, { cognitoService, userModel }) => {
   await cognitoService.addUser(email, password)
+
   const auth = await cognitoService.authenticate(email, password)
 
-  const user = await userModel.create({ email, password, name })
+  const user = await userModel.create({ email, password, ...restUserInput })
 
   return { id: user.id, name: user.name, email: user.email, token: auth.idToken.jwtToken }
 }

--- a/src/migrations/20201015013008-add-customer-and-seller-fields-to-user.js
+++ b/src/migrations/20201015013008-add-customer-and-seller-fields-to-user.js
@@ -1,0 +1,32 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.addColumn('user', 'street', { type: Sequelize.STRING }, { transaction })
+      await queryInterface.addColumn('user', 'streetNumber', { type: Sequelize.STRING }, { transaction })
+      await queryInterface.addColumn('user', 'city', { type: Sequelize.STRING }, { transaction })
+      await queryInterface.addColumn('user', 'state', { type: Sequelize.STRING }, { transaction })
+      await queryInterface.addColumn('user', 'flat', { type: Sequelize.STRING }, { transaction })
+      await queryInterface.addColumn('user', 'businessVertical', { type: Sequelize.STRING }, { transaction })
+      await queryInterface.addColumn('user', 'CUIT', { type: Sequelize.INTEGER }, { transaction })
+      await queryInterface.addColumn('user', 'AFIPCondition', {
+        type: Sequelize.ENUM({
+          values: ['ENROLLED_RESPONSIBLE', 'FINAL_CONSUMER']
+        })
+      }, { transaction })
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.removeColumn('user', 'street', { transaction })
+      await queryInterface.removeColumn('user', 'streetNumber', { transaction })
+      await queryInterface.removeColumn('user', 'city', { transaction })
+      await queryInterface.removeColumn('user', 'state', { transaction })
+      await queryInterface.removeColumn('user', 'flat', { transaction })
+      await queryInterface.removeColumn('user', 'businessVertical', { transaction })
+      await queryInterface.removeColumn('user', 'CUIT', { transaction })
+      await queryInterface.removeColumn('user', 'AFIPCondition', { transaction })
+      await queryInterface.sequelize.query(`DROP TYPE IF EXISTS "enum_user_AFIPCondition"`, { transaction })
+    })
+  }
+}

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,3 +1,5 @@
+const AFIP_CONDITION_VALUES = ['ENROLLED_RESPONSIBLE', 'FINAL_CONSUMER']
+
 export default (sequelize, DataTypes) => {
   const User = sequelize.define('user', {
     id: {
@@ -7,12 +9,44 @@ export default (sequelize, DataTypes) => {
     },
     name: {
       type: DataTypes.STRING,
-      alloNull: false
+      allowNull: false
     },
     email: {
       type: DataTypes.STRING,
       unique: true,
-      alloNull: false
+      allowNull: false
+    },
+    street: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    streetNumber: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    city: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    state: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    flat: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    businessVertical: {
+      type: DataTypes.STRING,
+      allowNull: true
+    },
+    CUIT: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: true
+    },
+    AFIPCondition: {
+      type: DataTypes.ENUM(...AFIP_CONDITION_VALUES),
+      allowNull: true
     }
   })
 

--- a/src/schema/types/user.graphql
+++ b/src/schema/types/user.graphql
@@ -16,6 +16,14 @@ input SignupInput {
   name: String!
   email: String!
   password: String!
+  street: String
+  streetNumber: String
+  city: String
+  state: String
+  flat: String
+  CUIT: Int
+  businessVertical: String
+  AFIPCondition: String
 }
 
 extend type Query {


### PR DESCRIPTION
I reaaaaaaaaaaaaaally feel like this User is going to become a fat model as it targets two actors (seller, customer). In a sense, a name for a customer will be the name of a person, like "Mauro". But in the case of sellers, it will be a "Razon Social" like "X company S.A". I attach the card description that I wrote for completition

> Tarea: Separar registro de vendedor y comprador

>Preocupacion: Son dos actores/stakeholders con responsabilidades distintas, si se representan en un solo modelo User, luego agregar campos (como tokens de mercadopago, referencias a AFIP) puede que no tengan sentido para uno u otro actor (se daria el caso que un comprador tenga info del AFIP vacia por ejemplo), algunos metodos de instancia tampoco tendrian sentido dependiendo el caso.
Soluciones pensadas:

>1 - Dejar User, agregar modelos Comprador y Vendedor. User encapsula la idea de "Persona", con DNI, E-mail, y datos que son mas sobre individuos que sobre reglas de negocio. User tiene relaciones 1:1 con Comprador y Vendedor, asi lo requiera, con los campos especificos a cada uno, que tienen mas apego a las reglas de negocio (tokens de mercadopago, cosas de AFIP, etc). La autenticacion se haria con User, y esto es flexible como para permitir que sea Comprador y Vendedor, o solo comprador, o solo vendedor (si a priori se quieren vendedores conocidos, entonces solo se crea la relacion con Vendedor una vez que nosotros aceptemos en algun lado a ese proveedor, pero dar de alta el vendedor seria una cuestion de crear la instancia en Vendedor con la relacion 1:1 a User).

>1 - v2: la misma logica pero en lugar de relaciones 1:1, se tiene que Vendedor/Comprador heredan de User (me parece mas complejo de implementar, se necesitaria sequelize-hierarchy)

>2- Crear el modelo Comprador, y que un modelo Vendedor herede de este. (todos pueden comprar, solo los vendedores pueden vender).

>3 - Meter todo en User --> Es mas rápido, pero se puede dar que un comprador puro tenga informacion vacia, ya que son campos que corresponden a un vendedor. Puede que el codigo se llene de instrucciones del tipo instancia.isVendedor(). Aca la definicion de vendedor se debe "calcular", por ejemplo, "si tiene CUIT --> es vendedor".