### PR TITLE
MP/ add payout method

### DIFF
--- a/src/migrations/20201021001745-create-payoutMethod.js
+++ b/src/migrations/20201021001745-create-payoutMethod.js
@@ -1,0 +1,37 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('payoutMethod', {
+      id: {
+        type: Sequelize.UUID,
+        primaryKey: true,
+        allowNull: false
+      },
+      businessId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'business',
+          key: 'id'
+        },
+        onUpdate: 'cascade',
+        onDelete: 'cascade'
+      },
+      type: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: true
+      }
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('payoutMethod')
+  }
+}

--- a/src/migrations/20201021002149-create-mercadoPagoPayoutMethod.js
+++ b/src/migrations/20201021002149-create-mercadoPagoPayoutMethod.js
@@ -1,0 +1,33 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('mercadoPagoPayoutMethod', {
+      id: {
+        type: Sequelize.UUID,
+        primaryKey: true,
+        allowNull: false
+      },
+      payoutMethodId: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'payoutMethod',
+          key: 'id'
+        },
+        onUpdate: 'cascade',
+        onDelete: 'cascade'
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: true
+      }
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('mercadoPagoPayoutMethod')
+  }
+}

--- a/src/migrations/20201021200622-add-defaultPayoutMethodId-to-business.js
+++ b/src/migrations/20201021200622-add-defaultPayoutMethodId-to-business.js
@@ -1,0 +1,16 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('business', 'defaultPayoutMethodId', {
+      type: Sequelize.UUID,
+      allowNull: true,
+      references: {
+        model: 'payoutMethod',
+        key: 'id'
+      }
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('business', 'defaultPayoutMethodId')
+  }
+}

--- a/src/models/business.js
+++ b/src/models/business.js
@@ -22,6 +22,10 @@ export default (sequelize, DataTypes) => {
       foreignKey: 'businessId',
       as: 'users'
     })
+    Business.belongsTo(models.payoutMethod, {
+      foreignKey: 'defaultPayoutMethodId',
+      as: 'defaultPayoutMethod'
+    })
   }
 
   return Business

--- a/src/models/mercadoPagoPayoutMethod.js
+++ b/src/models/mercadoPagoPayoutMethod.js
@@ -17,14 +17,12 @@ export default (sequelize, DataTypes) => {
     }
   })
 
+  MercadoPagoPayoutMethod.prototype.payout = function (options) {
+    console.log('Mercado pago payout placeholder')
+  }
+
   MercadoPagoPayoutMethod.associate = (models) => {
-    MercadoPagoPayoutMethod.belongsTo(models.payoutMethod, {
-      foreignKey: 'payoutMethodId',
-      constraints: false,
-      scope: {
-        type: 'MercadoPagoPayoutMethod'
-      }
-    })
+    MercadoPagoPayoutMethod.belongsTo(models.payoutMethod)
   }
 
   return MercadoPagoPayoutMethod

--- a/src/models/mercadoPagoPayoutMethod.js
+++ b/src/models/mercadoPagoPayoutMethod.js
@@ -1,0 +1,31 @@
+export default (sequelize, DataTypes) => {
+  const MercadoPagoPayoutMethod = sequelize.define('mercadoPagoPayoutMethod', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      allowNull: false
+    },
+    payoutMethodId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: 'payoutMethod',
+        key: 'id'
+      },
+      onUpdate: 'cascade',
+      onDelete: 'cascade'
+    }
+  })
+
+  MercadoPagoPayoutMethod.associate = (models) => {
+    MercadoPagoPayoutMethod.belongsTo(models.payoutMethod, {
+      foreignKey: 'payoutMethodId',
+      constraints: false,
+      scope: {
+        type: 'MercadoPagoPayoutMethod'
+      }
+    })
+  }
+
+  return MercadoPagoPayoutMethod
+}

--- a/src/models/mercadoPagoPayoutMethod.js
+++ b/src/models/mercadoPagoPayoutMethod.js
@@ -18,7 +18,7 @@ export default (sequelize, DataTypes) => {
   })
 
   MercadoPagoPayoutMethod.prototype.payout = function (options) {
-    console.log('Mercado pago payout placeholder')
+    // TODO: Implement the correct logic with the MercadoPago details
   }
 
   MercadoPagoPayoutMethod.associate = (models) => {

--- a/src/models/payoutMethod.js
+++ b/src/models/payoutMethod.js
@@ -1,0 +1,42 @@
+import { isEmpty, upperFirst } from 'lodash'
+
+export default (sequelize, DataTypes) => {
+  const PayoutMethod = sequelize.define('payoutMethod', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      allowNull: false
+    },
+    businessId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: 'business',
+        key: 'id'
+      },
+      onUpdate: 'cascade',
+      onDelete: 'cascade'
+    },
+    type: {
+      type: DataTypes.STRING,
+      allowNull: false
+    }
+  })
+
+  PayoutMethod.prototype.getMethod = function(options) {
+    if (isEmpty(this.type)) return Promise.resolve(null)
+
+    const mixinMethodName = `get${upperFirst(this.type)}`
+
+    return this[mixinMethodName](options) //getMercadoPago....
+  }
+
+  PayoutMethod.associate = (models) => {
+    PayoutMethod.belongsTo(models.business)
+    PayoutMethod.hasOne(models.mercadoPagoPayoutMethod, {
+      foreignKey: 'payoutMethodId'
+    })
+  }
+
+  return PayoutMethod
+}

--- a/src/models/payoutMethod.js
+++ b/src/models/payoutMethod.js
@@ -23,12 +23,12 @@ export default (sequelize, DataTypes) => {
     }
   })
 
-  PayoutMethod.prototype.getMethod = function(options) {
+  PayoutMethod.prototype.getMethod = function (options) {
     if (isEmpty(this.type)) return Promise.resolve(null)
 
     const mixinMethodName = `get${upperFirst(this.type)}`
 
-    return this[mixinMethodName](options) //getMercadoPago....
+    return this[mixinMethodName](options)
   }
 
   PayoutMethod.associate = (models) => {


### PR DESCRIPTION
This is intended to be an extensible solution. Creating a `PayoutMethod` should be something like:

```
Payout.create(..., type= 'mercadoPagoPayoutMethod')
```

A business can have multiple payout methods, a query will be added to the business model with an include to proportionate a list of payout methods. 

A single `PayoutMethod` has a `getMethod`, which proportionates the necessary PayoutMethod instance.

If the `type` is `mercadoPagoPayoutMethod`, then the `getMethod` becomes `getMercadoPagoPayoutMethod`, which returns the associated `MercadoPagoPayoutMethod` instance.

```
Payout.getMethod() ==> Payout.getMercadoPagoPayoutMethod()
```

This `MercadoPagoPayoutMethod` is intended to have `payout` (any `PayoutMethod` should have it, so we have duck-typing here). This `payout` encapsulates the logic behind making a payment with `MercadoPago` (which will be populated in following PR's)


---------------

Should we need another `PayoutMethod` specialization, for example for Paypal, then the following should be done:

- Adding the association in `PayoutMethod`, e.g: `PayoutMethod.hasOne(paypalPayoutMethod)`

- Implement paypalPayoutMethod model, having it's own version of `payout`


And of course, taking into consideration that creating this instance should be `Payout.create(..., type='paypalPayoutMethod')`