### PR TITLE
MP/ Add person interface for user personal information

### DIFF
--- a/src/controllers/person/index.js
+++ b/src/controllers/person/index.js
@@ -1,0 +1,55 @@
+import { isEmpty } from 'lodash'
+
+export const getAddress = (obj) => obj.getPhysicalAddress()
+
+export const getPersonalInformation = async (obj, { userId }, { models }) => {
+  const person = await models.person.findOne({ where: { userId } })
+
+  if (isEmpty(person)) throw new Error('Provided UserId could not be found in the database.')
+
+  return person
+}
+
+export const setPersonalInformation = (obj, { userId, personalInformation }, { models }) => {
+  return models.sequelize.transaction(async (transaction) => {
+    const {
+      firstName,
+      lastName,
+      dni,
+      address: addressInput
+    } = personalInformation
+
+    const user = await models.user.findByPk(userId, { transaction })
+
+    if (isEmpty(user)) throw new Error('Provided UserId could not be found in the database.')
+
+    const person = await models.person.findOne({ where: { userId }, transaction })
+
+    if (isEmpty(person)) {
+      return models.person.create({
+        userId,
+        firstName,
+        lastName,
+        dni,
+        physicalAddress: addressInput
+      }, {
+        transaction,
+        include: [{
+          association: models.person.PhysicalAddress
+        }]
+      })
+    }
+
+    await person.update({
+      firstName,
+      lastName,
+      dni
+    }, { transaction })
+
+    const address = await person.getPhysicalAddress({ transaction })
+
+    await address.update(addressInput, { transaction })
+
+    return person
+  })
+}

--- a/src/migrations/20201028200334-change-person-dni-to-be-nullable.js
+++ b/src/migrations/20201028200334-change-person-dni-to-be-nullable.js
@@ -1,0 +1,15 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn('person', 'dni', {
+      type: Sequelize.INTEGER,
+      allowNull: true
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn('person', 'dni', {
+      type: Sequelize.INTEGER,
+      allowNull: false
+    })
+  }
+}

--- a/src/models/person.js
+++ b/src/models/person.js
@@ -15,7 +15,7 @@ export default (sequelize, DataTypes) => {
     },
     dni: {
       type: DataTypes.INTEGER,
-      allowNull: false
+      allowNull: true
     },
     userId: {
       type: DataTypes.UUID,
@@ -24,7 +24,7 @@ export default (sequelize, DataTypes) => {
   })
 
   Person.associate = (models) => {
-    Person.belongsTo(models.physicalAddress)
+    Person.PhysicalAddress = Person.belongsTo(models.physicalAddress)
     Person.belongsTo(models.user)
   }
 

--- a/src/schema/resolvers/person.js
+++ b/src/schema/resolvers/person.js
@@ -1,0 +1,15 @@
+import * as personController from '~/src/controllers/person'
+
+const resolvers = {
+  Person: {
+    address: personController.getAddress
+  },
+  Query: {
+    getPersonalInformation: personController.getPersonalInformation
+  },
+  Mutation: {
+    setPersonalInformation: personController.setPersonalInformation
+  }
+}
+
+export default resolvers

--- a/src/schema/types/person.graphql
+++ b/src/schema/types/person.graphql
@@ -1,0 +1,21 @@
+type Person {
+  id: ID!
+  firstName: String!
+  lastName: String!
+  address: Address!
+}
+
+input PersonalInformationInput {
+ firstName: String!
+ lastName: String!
+ address: AddressInput!
+ dni: Int
+}
+
+extend type Query {
+  getPersonalInformation(userId: ID!): Person!
+}
+
+extend type Mutation {
+  setPersonalInformation(userId: ID!, personalInformation: PersonalInformationInput!): Person!
+}


### PR DESCRIPTION
Added the personal information interface, I chose to do a `setPersonalInformation` which creates or modifies existing information (including address, which is provided as part of the Person information, although they are two tables). 

I tried to do an `upsert` to update or insert an existing instance, but due to it not supporting the `include` (as `create` does) to modify the association, I had to do it manually.